### PR TITLE
[Tappy] Spawn infinite pipes at random Y-axis coordinates

### DIFF
--- a/TappyPlane/game/game.gd
+++ b/TappyPlane/game/game.gd
@@ -1,0 +1,36 @@
+extends Node2D
+
+
+@export var pipes_scene: PackedScene
+
+
+@onready var pipes_holder = $PipesHolder
+@onready var spawn_u = $SpawnU
+@onready var spawn_l = $SpawnL
+@onready var spawn_timer = $SpawnTimer
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	spawn_pipes()
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(_delta):
+	pass
+
+
+# Spawn a new set of vertical pipes (an upper pipe and a lower pipe)
+# at a random Y-axis coordinate, slightly off-screen on the right side.
+func spawn_pipes() -> void:
+	var y_pos = randf_range(spawn_u.position.y, spawn_l.position.y)
+	var new_pipes = pipes_scene.instantiate()
+	
+	new_pipes.position = Vector2(spawn_l.position.x, y_pos)
+	pipes_holder.add_child(new_pipes)
+
+
+# Invoked every 1.2 seconds.
+func _on_spawn_timer_timeout():
+	print("Timer: Spawning pipes ...")
+	spawn_pipes()

--- a/TappyPlane/game/game.tscn
+++ b/TappyPlane/game/game.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://d3s3jarsblept"]
+[gd_scene load_steps=6 format=3 uid="uid://d3s3jarsblept"]
 
+[ext_resource type="Script" path="res://game/game.gd" id="1_8mvgv"]
 [ext_resource type="Texture2D" uid="uid://cipn3jachofck" path="res://assets/background/rocks_2.png" id="1_y1i6m"]
 [ext_resource type="PackedScene" uid="uid://bh6to4cyow4el" path="res://plane_cb/plane_cb.tscn" id="2_u2rx7"]
 [ext_resource type="PackedScene" uid="uid://58mvkh7l2x2w" path="res://pipes/pipes.tscn" id="3_wyk8c"]
@@ -8,6 +9,8 @@
 size = Vector2(543, 20)
 
 [node name="Game" type="Node2D"]
+script = ExtResource("1_8mvgv")
+pipes_scene = ExtResource("3_wyk8c")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(91, 318)
@@ -23,11 +26,16 @@ position = Vector2(0, 862)
 position = Vector2(241.5, 0)
 shape = SubResource("RectangleShape2D_n6i4d")
 
-[node name="Pipes" parent="." instance=ExtResource("3_wyk8c")]
-position = Vector2(212, 328)
+[node name="PipesHolder" type="Node" parent="."]
 
-[node name="Pipes2" parent="." instance=ExtResource("3_wyk8c")]
-position = Vector2(351, 256)
+[node name="SpawnU" type="Marker2D" parent="."]
+position = Vector2(520, 340)
 
-[node name="Pipes3" parent="." instance=ExtResource("3_wyk8c")]
-position = Vector2(477, 410)
+[node name="SpawnL" type="Marker2D" parent="."]
+position = Vector2(520, 540)
+
+[node name="SpawnTimer" type="Timer" parent="."]
+wait_time = 1.2
+autostart = true
+
+[connection signal="timeout" from="SpawnTimer" to="." method="_on_spawn_timer_timeout"]

--- a/TappyPlane/pipes/pipes.gd
+++ b/TappyPlane/pipes/pipes.gd
@@ -1,12 +1,12 @@
 extends Node2D
 
 
-const SCROLL_SPEED: float = 50.0
+const SCROLL_SPEED: float = 120.0
 
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
+	print("Pipe created ... %s (%s, %s)" % [name, position.x, position.y])
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/TappyPlane/pipes/pipes.tscn
+++ b/TappyPlane/pipes/pipes.tscn
@@ -17,6 +17,7 @@ rotation = 3.14159
 position = Vector2(2.08165e-12, 80)
 
 [node name="VisibleOnScreenEnabler2D" type="VisibleOnScreenEnabler2D" parent="."]
-position = Vector2(79, 0)
+position = Vector2(-32, 0)
+rect = Rect2(-10, -10, 120, 20)
 
 [connection signal="screen_exited" from="VisibleOnScreenEnabler2D" to="." method="_on_screen_exited"]


### PR DESCRIPTION
- Fixes the width of the `VisibleOnScreenEnabler2D` for the pipes so that the pipes will scroll correctly (otherwise they just spawn off-screen and immediately become dead objects).