### PR TITLE
[Tappy] Fix the 'is_inside_tree()' error for spawned pipes

### DIFF
--- a/TappyPlane/game/game.gd
+++ b/TappyPlane/game/game.gd
@@ -37,6 +37,10 @@ func _process(_delta):
 
 # Spawn a new set of vertical pipes (an upper pipe and a lower pipe)
 # at a random Y-axis coordinate, slightly off-screen on the right side.
+# In order to fix this error:
+# game.gd:45 @ spawn_pipes(): Condition "!is_inside_tree()" is true. Returning: false
+# You need to make sure the 'VisibleOnScreenEnabler2D' is positioned at the bottom
+# of the Pipes Node hierarchy.
 func spawn_pipes() -> void:
 	var y_pos = randf_range(spawn_u.position.y, spawn_l.position.y)
 	var new_pipes = pipes_scene.instantiate()

--- a/TappyPlane/pipes/pipes.tscn
+++ b/TappyPlane/pipes/pipes.tscn
@@ -17,13 +17,13 @@ rotation = 3.14159
 [node name="Lower" parent="." instance=ExtResource("2_0fb3e")]
 position = Vector2(2.08165e-12, 80)
 
-[node name="VisibleOnScreenEnabler2D" type="VisibleOnScreenEnabler2D" parent="."]
-position = Vector2(-32, 0)
-rect = Rect2(-10, -10, 120, 20)
-
 [node name="ScoreSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("4_dqpit")
 volume_db = -5.0
+
+[node name="VisibleOnScreenEnabler2D" type="VisibleOnScreenEnabler2D" parent="."]
+position = Vector2(-32, 0)
+rect = Rect2(-10, -10, 120, 20)
 
 [connection signal="body_entered" from="Laser" to="." method="_on_laser_body_entered"]
 [connection signal="body_entered" from="Upper" to="." method="_on_pipe_body_entered"]


### PR DESCRIPTION
## Description
When the `ScoreSound` was introduced in the `pipes` scene, a frequent error started occurring whenever new pipes were spawned:
```
E 0:00:02:0452   game.gd:45 @ spawn_pipes(): Condition "!is_inside_tree()" is true. Returning: false
  <C++ Source>   scene/main/node.cpp:762 @ can_process()
  <Stack Trace>  game.gd:45 @ spawn_pipes()
                 game.gd:30 @ _ready()
```

The fix is to move the `VisibleOnScreenEnabler2D` to the bottom of the `Pipes` Node hierarchy.

Resolves Issue: https://github.com/HelloImKevo/GodotSimpleGames/issues/6