### PR TITLE
[Foxy] Important fix for processing off-screen physics using VisibleOnScreenNotifier2D

### DIFF
--- a/FoxyAntics/enemies/eagle/eagle.tscn
+++ b/FoxyAntics/enemies/eagle/eagle.tscn
@@ -63,3 +63,5 @@ target_position = Vector2(2.08165e-12, 200)
 
 [node name="DirectionTimer" type="Timer" parent="." index="5"]
 wait_time = 3.0
+
+[connection signal="timeout" from="DirectionTimer" to="." method="_on_direction_timer_timeout"]

--- a/FoxyAntics/enemies/enemy_base/enemy_base.gd
+++ b/FoxyAntics/enemies/enemy_base/enemy_base.gd
@@ -41,7 +41,7 @@ func _ready():
 	_player_ref = get_tree().get_nodes_in_group(GameManager.GROUP_PLAYER)[0]
 
 
-func _physics_process(delta):
+func _physics_process(_delta):
 	assert(_internal_ready_called, "Subclasses must invoke super._ready()")
 	_fallen_off()
 
@@ -79,6 +79,7 @@ func _on_post_physics_process() -> void:
 
 func _fallen_off() -> void:
 	if global_position.y > OFF_SCREEN_KILL_ME:
+		print(_to_string(), " => This enemy went way-off screen. Queuing it for destruction.")
 		# Hasta la vista, baby: Mark this enemy as ready to be destroyed.
 		queue_free()
 
@@ -113,11 +114,11 @@ func get_distance_to_player() -> float:
 
 #region: Node Signals
 
-func _on_screen_entered():
+func _on_visible_on_screen():
 	pass # Replace with function body.
 
 
-func _on_screen_exited():
+func _on_not_visible_on_screen():
 	pass # Replace with function body.
 
 #endregion: Node Signals

--- a/FoxyAntics/enemies/enemy_base/enemy_base.tscn
+++ b/FoxyAntics/enemies/enemy_base/enemy_base.tscn
@@ -5,7 +5,7 @@
 [node name="EnemyBase" type="CharacterBody2D"]
 script = ExtResource("1_cfmw3")
 
-[node name="VisibleOnScreenEnabler2D" type="VisibleOnScreenEnabler2D" parent="."]
+[node name="VisibleOnScreenNotifier2D" type="VisibleOnScreenNotifier2D" parent="."]
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 
@@ -21,5 +21,5 @@ text = "Enemy Debug Label
 pos.x = 500 pos.y = 800
 velocity.x = 5 velocity.y = -9.8"
 
-[connection signal="screen_entered" from="VisibleOnScreenEnabler2D" to="." method="_on_screen_entered"]
-[connection signal="screen_exited" from="VisibleOnScreenEnabler2D" to="." method="_on_screen_exited"]
+[connection signal="screen_entered" from="VisibleOnScreenNotifier2D" to="." method="_on_visible_on_screen"]
+[connection signal="screen_exited" from="VisibleOnScreenNotifier2D" to="." method="_on_not_visible_on_screen"]

--- a/FoxyAntics/enemies/frog/frog.gd
+++ b/FoxyAntics/enemies/frog/frog.gd
@@ -100,11 +100,11 @@ func _on_jump_timer_timeout():
 	_jump_allowed = true
 
 
-func _on_screen_entered():
+func _on_visible_on_screen():
 	_seen_player = true
 
 
-func _on_screen_exited():
+func _on_not_visible_on_screen():
 	pass # Replace with function body.
 
 #endregion: Node Signals

--- a/FoxyAntics/level_base/level_base.gd
+++ b/FoxyAntics/level_base/level_base.gd
@@ -13,11 +13,6 @@ func _ready():
 	pass # Replace with function body.
 
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(_delta):
-	pass
-
-
 func _physics_process(_delta):
 	# Anchor the 2D camera viewport to the player's position.
 	# We want all the physics processing to be calculated before

--- a/FoxyAntics/level_base/level_base.tscn
+++ b/FoxyAntics/level_base/level_base.tscn
@@ -535,4 +535,7 @@ position = Vector2(769, -49)
 position = Vector2(366, -183)
 
 [node name="Eagle" parent="." instance=ExtResource("7_nif1s")]
-position = Vector2(552, -268)
+position = Vector2(487, -233)
+
+[node name="Eagle2" parent="." instance=ExtResource("7_nif1s")]
+position = Vector2(84, -294)

--- a/FoxyAntics/player_cam/player_cam.gd
+++ b/FoxyAntics/player_cam/player_cam.gd
@@ -4,8 +4,3 @@ extends Camera2D
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(_delta):
-	pass


### PR DESCRIPTION
I had mistakenly added a `VisibleOnScreenEnabler2D` rather than a 
`VisibleOnScreenNotifier2D`, which makes all the difference. Double-check to 
make sure you are using a "Notifier2D" rather than the "Enabler2D". 

From the docs:

> The target node will be automatically enabled (via its `Node.process_mode` 
> property) when any part of this region becomes visible on the screen, and 
> automatically disabled otherwise. This can for example be used to activate 
> enemies only when the player approaches them.
> 
> See `VisibleOnScreenNotifier2D` if you only want to be notified when the 
> region is visible on screen.

Also implemented the movement logic for the `Eagle.gd` enemy.