### PR TITLE
[Foxy] Make platform edge jumping more forgiving with a RayCast2D

### DIFF
--- a/FoxyAntics/player/player.tscn
+++ b/FoxyAntics/player/player.tscn
@@ -166,6 +166,10 @@ texture = ExtResource("1_i5ifk")
 hframes = 19
 frame = 13
 
+[node name="PlatformJumpDetection" type="RayCast2D" parent="."]
+position = Vector2(-22, -6)
+target_position = Vector2(2.08165e-12, 30)
+
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, 6)
 shape = SubResource("RectangleShape2D_7p6b2")


### PR DESCRIPTION
## Description:
The `is_on_floor()` function is not very forgiving - as soon as the player runs
at a high speed off the edge of a platform, they could not longer jump. Now
the `RayCast2D` gives you a forgiving window, making the platform jumping more
fun. While testing this, I found you could cheese the system with infinite
jumps while being near any "platform". The boolean flag prevents that.

## Resolves Issue:
https://github.com/HelloImKevo/GodotSimpleGames/issues/15